### PR TITLE
cart_itemsコントローラーの記述変更、orderコントローラーに諸々の記述。

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -64,7 +64,7 @@ gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 gem 'devise'
 
 gem 'enum_help'
-
+gem 'pry-rails'
 gem 'rails-i18n'
 
 gem 'enumerize'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -79,6 +79,7 @@ GEM
     chromedriver-helper (2.1.1)
       archive-zip (~> 0.10)
       nokogiri (~> 1.8)
+    coderay (1.1.2)
     coffee-rails (4.2.2)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0)
@@ -145,6 +146,11 @@ GEM
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
+    pry-rails (0.3.9)
+      pry (>= 0.10.4)
     public_suffix (4.0.4)
     puma (3.12.4)
     rack (2.2.2)
@@ -273,6 +279,7 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   listen (>= 3.0.5, < 3.2)
+  pry-rails
   puma (~> 3.11)
   rails (~> 5.2.4, >= 5.2.4.2)
   rails-i18n

--- a/app/controllers/cart_items_controller.rb
+++ b/app/controllers/cart_items_controller.rb
@@ -1,14 +1,16 @@
 class CartItemsController < ApplicationController
 
 	def index
-		@cart_items = CartItem.all
+		@member = current_member
+		@cart_items = @member.cart_items.all
 		@sum = 0
 	end
 
 	def create
+		@member = current_member
 		@product = Product.find(params[:cart_item][:product_id])
-		if CartItem.exists?(product_id: @product)
-		@cart_item = CartItem.find_by(product_id: @product.id)
+		if CartItem.exists?(product_id: @product, member_id: @member)
+		@cart_item = CartItem.find_by(product_id: @product.id, member_id: @member)
 		@cart_item.quantity += params[:cart_item][:quantity].to_i
 		@cart_item.update(quantity: @cart_item.quantity)
 		else

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -32,9 +32,16 @@ class OrdersController < ApplicationController
 	end
 
 	def create
+		@order = Order.new(order_params)
+		@order.save
+		redirect_to orders_thanks_member_path
 	end
 
 	def thanks
+	end
+
+	def order_params
+		params.require(:order).permit(:member_id,:name, :postcode, :address, :payment_method, :order_status)
 	end
 
 end

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -33,15 +33,33 @@ class OrdersController < ApplicationController
 
 	def create
 		@order = Order.new(order_params)
+		@member = current_member
 		@order.save
+		#ここに新規お届け先を登録した場合、配送先一覧に保存される動きを追加する！！！
+		
+		
+		
+		
+		
+		@cart_items = @member.cart_items.all
+		# 一つ上で全件取得したquantityを１件ずつ取得するeach文
+		@cart_items.each do |cart_item|
+		@order_item = OrderItem.new
+		@order_item.order_id = @order.id
+		@order_item.product_id = cart_item.product_id
+		@order_item.quantity = cart_item.quantity
+		@order_item.price = cart_item.product.price
+		@order_item.save
+		end
+		current_member.cart_items.destroy_all
 		redirect_to orders_thanks_member_path
 	end
 
 	def thanks
 	end
 
+
 	def order_params
 		params.require(:order).permit(:member_id,:name, :postcode, :address, :payment_method, :order_status)
 	end
-
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -3,4 +3,5 @@ class Order < ApplicationRecord
   has_many :order_items, dependent: :destroy
 
   enum payment_method:{credit_card: 0, bank_transfer: 1}
+  enum order_status:{waiting: 0, confirm: 1, in_production: 2, preparation: 3, shipped:4}
 end

--- a/app/models/order_item.rb
+++ b/app/models/order_item.rb
@@ -1,4 +1,6 @@
 class OrderItem < ApplicationRecord
   belongs_to :order
   belongs_to :product
+
+  enum production_status:{ cant: 0,waiting: 1, working: 2, completed: 3 }
 end

--- a/app/views/orders/confirm.html.erb
+++ b/app/views/orders/confirm.html.erb
@@ -12,6 +12,7 @@
 		<tr>
 			<td>
 				<%= cart_item.product.name %>
+				<%= cart_item.product.price %>
 			</td>
 		</tr>
 	</tbody>
@@ -31,7 +32,6 @@
 <%= f.hidden_field :name, :value => @order.name %><br>
 <%= f.hidden_field :postcode, :value => @order.postcode %><br>
 <%= f.hidden_field :address, :value => @order.address %><br>
-
 
 <%= f.submit '購入確定' %>
 <% end %>

--- a/app/views/orders/confirm.html.erb
+++ b/app/views/orders/confirm.html.erb
@@ -25,6 +25,16 @@
 郵便番号<%= @order.postcode %><br>
 住所<%= @order.address %><br>
 
+<%= form_for(@order, url:member_orders_path, method: :post) do |f| %>
+<%= f.hidden_field :member_id, :value => @current_member.id %>
+<%= f.hidden_field :payment_method, :value => @order.payment_method %><br>
+<%= f.hidden_field :name, :value => @order.name %><br>
+<%= f.hidden_field :postcode, :value => @order.postcode %><br>
+<%= f.hidden_field :address, :value => @order.address %><br>
+
+
+<%= f.submit '購入確定' %>
+<% end %>
 
 <%= link_to '戻る', :back, class: "btn btn-default" %>
 </div>

--- a/app/views/orders/new.html.erb
+++ b/app/views/orders/new.html.erb
@@ -23,8 +23,8 @@
         <%= radio_button :order_info, :address_kind, :new_address %>
         新しいお届け先<br>
 		郵便番号(ハイフンなし)<%= text_field :order_info, :new_postcode %><br/>
-		住所　　　　　　　　　<%= text_field :order_info, :new_address %><br/>
-		宛名　　　　　　　　　<%= text_field :order_info, :new_name %><br/>
+		住所 <%= text_field :order_info, :new_address %><br/>
+		宛名 <%= text_field :order_info, :new_name %><br/>
 
 		<%= submit_tag ("確認画面へ進む"),class: "btn btn-default" %>
 		<% end %>


### PR DESCRIPTION
カートアイテムに各ユーザーが追加したカートアイテムがそれぞれ表示されるようにした。
（どのユーザーが追加しても、カートの中身が増えてしまう現象を解決）

オーダーコントローラーに住所、名前、郵便番号　オーダーアイテムテーブルに注文時価格、注文個数、製作ステータス（着手不可）が保存されるように記述。